### PR TITLE
chore(deps): pin picomatch to 2.3.2 to fix Dependabot method-injectio…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9176,10 +9176,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lodash": "4.18.0",
     "flatted": "3.4.2",
     "fast-xml-parser": "5.7.0",
-    "minimatch": "3.1.3"
+    "minimatch": "3.1.3",
+    "picomatch": "2.3.2"
   },
   "scripts": {
     "lint": "eslint **/{aura,lwc}/**/*.js",


### PR DESCRIPTION
Commits in the PR:
- 📝 f50f37b chore(deps): pin picomatch to 2.3.2 to fix Dependabot method-injectio…