### PR TITLE
chore(deps): pin js-yaml to 3.14.2 to fix prototype-pollution alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8075,10 +8075,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "flatted": "3.4.2",
     "fast-xml-parser": "5.7.0",
     "minimatch": "3.1.3",
-    "picomatch": "2.3.2"
+    "picomatch": "2.3.2",
+    "js-yaml": "3.14.2"
   },
   "scripts": {
     "lint": "eslint **/{aura,lwc}/**/*.js",


### PR DESCRIPTION
Commits in the PR:
- 📝 23c8438 chore(deps): pin js-yaml to 3.14.2 to fix prototype-pollution alert